### PR TITLE
Add new GO http.ServeMux snippets

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -209,6 +209,21 @@
         "body": "http.Serve(\"${1::8080}\", ${2:nil})",
         "description": "Snippet for http.Serve"
     },
+    "http.NewServeMux()": {
+        "prefix": "nmx",
+        "body": "mux := http.NewServeMux()".
+        "description": "Snippet for http.NewServeMux()",
+    },
+    "http.ServeMux.HandleFunc": {
+        "prefix": "mhf",
+        "body": "mux.HandleFunc(\"${1:/}\", ${2:function})".
+        "description": "Snipper for http.ServeMux.HandleFunc()",
+    },
+    "http.ServeMux.Handle": {
+        "prefix": "mh",
+        "body": "mux.Handle(\"${1:/}\", ${2:handler})".
+        "description": "",
+    },
     "goroutine anonymous function": {
         "prefix": "go",
         "body": "go func($1) {\n\t$0\n}($2)",

--- a/snippets/go.json
+++ b/snippets/go.json
@@ -211,17 +211,17 @@
     },
     "http.NewServeMux()": {
         "prefix": "nmx",
-        "body": "mux := http.NewServeMux()".
+        "body": "mux := http.NewServeMux()",
         "description": "Snippet for http.NewServeMux()",
     },
     "http.ServeMux.HandleFunc": {
         "prefix": "mhf",
-        "body": "mux.HandleFunc(\"${1:/}\", ${2:function})".
+        "body": "mux.HandleFunc(\"${1:/}\", ${2:function})",
         "description": "Snipper for http.ServeMux.HandleFunc()",
     },
     "http.ServeMux.Handle": {
         "prefix": "mh",
-        "body": "mux.Handle(\"${1:/}\", ${2:handler})".
+        "body": "mux.Handle(\"${1:/}\", ${2:handler})",
         "description": "",
     },
     "goroutine anonymous function": {


### PR DESCRIPTION
Added new go snippets for http.ServeMux

Added

mux := http.NewServeMux() - Prefix "nmx"
mux.HandleFunc("/", function) - Prefix "mhf"
mux.Handle("/", handler) - Prefix "mh"
